### PR TITLE
Remove showcase submission form

### DIFF
--- a/pages/showcase.html
+++ b/pages/showcase.html
@@ -255,13 +255,6 @@ layout: default
 		{% endif %}
 		{% endfor %}
 	</section>
-
-	<p style="margin-top: 3rem" id="submit-project">
-		<strong>Interested in showcasing your published game on this page?</strong>
-		Use <a
-			href="https://docs.google.com/forms/d/e/1FAIpQLSdhNEywWfk7tm4ABSxmPfnJrKwGPAoYbzRfZlHmu9iZ5CJ5Pw/viewform?usp=sf_link">this
-			form</a>.
-	</p>
 </div>
 
 {% include footer.html %}


### PR DESCRIPTION
The form is currently not working. Long term we should probably find a proper solution, but for now a quick fix is to remove the link so that people are not misguided.